### PR TITLE
content: Independent Builder umbrella entry (replaces ShieldRA)

### DIFF
--- a/src/components/Experience.astro
+++ b/src/components/Experience.astro
@@ -1,12 +1,12 @@
 ---
 const experiences = [
   {
-    company: "ShieldRA",
-    role: "PM / GTM Lead",
+    company: "Independent Builder",
+    role: "Fractional PM / Founder",
     period: "2026 – Present",
-    badge: "HealthTech",
-    summary: "Leading product and go-to-market strategy for HIPAA-compliant AI platform. Building compliance infrastructure, customer discovery pipeline, and positioning in the healthcare AI/automation space.",
-    products: "AI-powered compliance automation, healthcare system integrations",
+    badge: "Founder",
+    summary: "Building three products in parallel while consulting and exploring Sr. PM, Head of Product, and Director-level opportunities. Shipping real software while staying sharp on product strategy, GTM, and agentic AI.",
+    products: "DojoGate (B2B CRM for hardware & distribution SMBs) · ShieldRA (HIPAA compliance AI) · DocHaven (AI document intelligence)",
     icon: `<path d="M9 12l2 2 4-4m7 0a9 9 0 11-18 0 9 9 0 0118 0z" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"/>`
   },
   {


### PR DESCRIPTION
Replaces the ShieldRA-only experience card with an 'Independent Builder / Fractional PM' umbrella entry that lists all 3 projects (DojoGate, ShieldRA, DocHaven). Cleaner signal for recruiters — reads as actively building, not employed by ShieldRA.