### PR TITLE
content: fix misattributed claims + Orbex copy cleanup

### DIFF
--- a/src/components/About.astro
+++ b/src/components/About.astro
@@ -24,7 +24,7 @@
         </p>
         <p class="text-text-secondary leading-relaxed text-base sm:text-lg text-center sm:text-left">
           Most recently at Orbex Group as sole PM — built the first product roadmap from scratch, 
-          secured $1M in strategic funding, and deployed a 9-agent autonomous AI system in production. 
+          secured $1M in strategic funding, and drove analytics and CRM infrastructure from zero. 
           Before that, I directed a $200M+ portfolio at Viessmann and spent 8 years at Baker Hughes 
           progressing from design engineer to global product manager.
         </p>

--- a/src/components/Experience.astro
+++ b/src/components/Experience.astro
@@ -14,7 +14,7 @@ const experiences = [
     role: "Senior Product Manager",
     period: "2023 – Mar 2026",
     badge: "Automation",
-    summary: "Built the first product roadmap from scratch for motorized drive solutions in AGV/AMR robotics. Secured $1M in funding, cut time-to-market by 15%, and deployed a 9-agent autonomous AI system in production.",
+    summary: "Sole PM at a B2B hardware distribution company. Built the first product roadmap from scratch, secured $1M in strategic funding, deployed Power BI analytics infrastructure, and launched a CRM system that cut unqualified leads 60%.",
     products: "Wheel Drives, BLDC motors, slip rings — robotics, drones, humanoids",
     icon: `<path d="M13 10V3L4 14h7v7l9-11h-7z" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"/>`
   },


### PR DESCRIPTION
Removes '9-agent autonomous AI system' from Orbex entry in both Experience.astro and About.astro — this belongs to the Independent Builder section, not Orbex. Replaces with accurate Orbex claims traceable to canonical resume (Power BI analytics, CRM launch, 60% lead quality improvement).