### PR TITLE
P1: hero copy, contact CTA, projects reframe

### DIFF
--- a/src/components/Contact.astro
+++ b/src/components/Contact.astro
@@ -11,11 +11,10 @@
     </div>
 
     <h2 class="text-3xl md:text-5xl font-bold mb-6 text-center" data-animate data-delay="100">
-      Let's build something<span class="gradient-text">.</span>
+      Let's talk product<span class="gradient-text">.</span>
     </h2>
     <p class="text-text-secondary text-lg mb-12 leading-relaxed max-w-xl mx-auto" data-animate data-delay="200">
-      Whether it's product strategy, a side project idea, or just a good conversation — 
-      I'm always open to connecting with interesting people.
+      Open to product leadership conversations. If you're building something worth working on — let's talk.
     </p>
 
     <div class="flex flex-col items-center gap-4" data-animate data-delay="300">

--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -13,7 +13,7 @@
         <span class="animate-ping absolute inline-flex h-full w-full rounded-full bg-green-400 opacity-75"></span>
         <span class="relative inline-flex rounded-full h-2.5 w-2.5 bg-green-400"></span>
       </span>
-      <span class="text-text-secondary text-sm font-mono">Always open for a conversation</span>
+      <span class="text-text-secondary text-sm font-mono">Open to new opportunities</span>
     </div>
 
     <!-- Name -->
@@ -26,7 +26,7 @@
 
     <!-- Subtitle -->
     <p class="animate-fade-up delay-200 mt-4 text-lg sm:text-xl md:text-2xl text-text-secondary font-light text-center sm:text-left">
-      Senior Product Manager — Hardware & Digital Solutions
+      Senior Product Manager — Hardware, SaaS & Agentic AI
     </p>
 
     <!-- Typing effect -->
@@ -70,6 +70,13 @@
         data-hover
       >
         Get in Touch
+      </a>
+      <a
+        href="mailto:bibekgh@gmail.com?subject=Resume%20Request&body=Hi%20Bibek%2C%20I%27d%20love%20to%20see%20your%20resume."
+        class="inline-flex items-center gap-2 px-5 sm:px-6 py-3 border border-border text-text-secondary rounded-lg hover:border-accent hover:text-accent transition-all text-sm sm:text-base"
+        data-hover
+      >
+        Request Resume
       </a>
     </div>
 

--- a/src/components/Projects.astro
+++ b/src/components/Projects.astro
@@ -25,10 +25,10 @@ const projects = [
     icon: `<path d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"/>`
   },
   {
-    title: "AI Agent Orchestration",
-    description: "Multi-agent system for task delegation and automation. Queue-driven architecture with file locking, intelligent model routing, and fire-and-forget communication patterns.",
+    title: "Personal AI Workflow System",
+    description: "Built a multi-agent AI operating system for personal product intelligence — research, execution, and decision support across content, operations, and strategy. Not a product; a force multiplier.",
     tags: ["AI/ML", "Node.js", "Multi-Agent", "Automation"],
-    status: "Active",
+    status: "Internal",
     icon: `<path d="M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"/>`
   },
   {


### PR DESCRIPTION
## Changes

### Hero
- Status tag: `Always open for a conversation` → `Open to new opportunities`
- Subtitle: `Hardware & Digital Solutions` → `Hardware, SaaS & Agentic AI`
- Added `Request Resume` CTA (mailto prefilled) — no public PDF

### Contact
- Headline: `Let's build something.` → `Let's talk product.`
- Sub-copy: tightened for job-seeker intent, removed the co-founder pitch tone

### Projects
- `AI Agent Orchestration` → `Personal AI Workflow System`
- Reframed as internal tool (not a market product)
- Status badge: `Active` → `Internal`

## QA
All copy changes verified against source files. Report: `workspace-qa/reports/personal-site/qa-enhancement-audit-20260402.md`

## Staging → Merge
Needs Bibek approval before merge to staging.